### PR TITLE
Allow secrets to be encrypted with a KMS key....

### DIFF
--- a/examples/dummy-secret/data.tf
+++ b/examples/dummy-secret/data.tf
@@ -1,0 +1,4 @@
+data "template_file" "example" {
+  template = file("/path/to/json")
+
+}

--- a/examples/dummy-secret/main.tf
+++ b/examples/dummy-secret/main.tf
@@ -7,16 +7,10 @@ module "secret" {
   
   name  = "dummy-secret"
   value = "password"
+  policy = data.template_file.example.rendered # Optional
+  kms_key_id = "arn:aws:kms:aws-region:account-id:key/key-id" # Optional
   tags = {
       whodunnit = "steven"
       why       = "example"
   }
-}
-
-output "secret" {
-  value = module.secret.secret
-}
-
-output "secret_version" {
-  value = module.secret.secret_version
 }

--- a/examples/dummy-secret/outputs.tf
+++ b/examples/dummy-secret/outputs.tf
@@ -1,0 +1,7 @@
+output "secret" {
+  value = module.secret.secret
+}
+
+output "secret_version" {
+  value = module.secret.secret_version
+}

--- a/main.tf
+++ b/main.tf
@@ -1,44 +1,13 @@
-# Variables 
-
-variable "name" {
-  description = "Name of secret to store"
-  type        = string
-}
-
-variable "value" {
-  description = "Secret value to store"
-  type        = string
-}
-
-variable "description" {
-  type    = string
-  default = "terraform-managed secret"
-}
-
-variable "tags" {
-  description = "User-Defined tags"
-  type        = map(string)
-  default     = {}
-}
-
 # Resources 
 
 resource "aws_secretsmanager_secret" "secret" {
-  name_prefix = var.name
-  tags = var.tags
+  name       = var.name
+  tags       = var.tags
+  policy     = var.policy
+  kms_key_id = var.kms_key_id
 }
 
 resource "aws_secretsmanager_secret_version" "secret" {
-  secret_id = aws_secretsmanager_secret.secret.id
+  secret_id     = aws_secretsmanager_secret.secret.id
   secret_string = var.value
-}
-
-# Outputs
-
-output "secret" {
-  value = aws_secretsmanager_secret.secret
-}
-
-output "secret_version" {
-  value = aws_secretsmanager_secret_version.secret
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,9 @@
+# Outputs
+
+output "secret" {
+  value = aws_secretsmanager_secret.secret
+}
+
+output "secret_version" {
+  value = aws_secretsmanager_secret_version.secret
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,32 @@
+# Variables 
+
+variable "name" {
+  description = "Name of secret to store"
+  type        = string
+}
+
+variable "value" {
+  description = "Secret value to store"
+  type        = string
+}
+
+variable "description" {
+  type    = string
+  default = "terraform-managed secret"
+}
+
+variable "tags" {
+  description = "User-Defined tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "policy" {
+  description = "Optional. The resource policy which controls access to the secret."
+  default     = null
+}
+
+variable "kms_key_id" {
+  description = "Optional. The KMS Key ID to encrypt the secret. KMS key arn or alias can be used."
+  default     = null
+}


### PR DESCRIPTION
This pull request allows secrets created using this Terraform module to be optionally encrypted with a KMS key. Additionally, we can also optionally specify a resource policy which controls access to the secret.